### PR TITLE
Fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Regarding authentication/authorization: in order to accept HTTPS requests from t
 
 ⚠️  This means we use `insecureSkipTLSVerify: true` in the APIService, which is [probably ok](https://github.com/kubernetes-sigs/metrics-server/issues/544) but obviously not recommended.
 
-Then, to talk to the metrics providers, we create a ServiceAccount with permissions to read metrics (see [templates/rbac.yaml](./templates/rbac.yaml)) and use its ServiceAccount token the communicate with the backends.
+Then, to talk to the metrics providers, we create a ServiceAccount with permissions to read metrics (see [templates/rbac.yaml](./templates/rbac.yaml)) and use its ServiceAccount token to communicate with the backends. This is required (rather than passing the token of the requester) because some requesters use X.509 certificates which cannot be passed through (at least not without modifying the backend services to parse them out of a header).
 
-⚠️  This hasn't been thoroughly reviewed for security and may expose metrics to cluster-local workloads without proper RBAC!
+⚠️  This means cluster-local workloads could see the metrics without RBAC
 
 ## Configure & install
 

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -4,60 +4,97 @@ kind: ConfigMap
 metadata:
   name: metricsmultiplexer
 data:
-  entrypoint.sh: |
+  reloader.sh: |
     #!/bin/sh
+    set -eu -o pipefail
 
-    # Generate self-signed SSL certs (not great!)
-    apk add openssl && openssl req -x509 -nodes -days 365 -subj "/C=NA/ST=NA/O=NA/CN=NA" -newkey rsa:2048 -keyout /etc/nginx/ssl.key -out /etc/nginx/ssl.crt
-
-    # Fill in the ServiceAccount token in the nginx config
+    # reload nginx config with new service account token
     TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
     cat multiplexer-nginx.conf | sed "s/KUBERNETESAUTHTOKEN/$TOKEN/" > /etc/nginx/conf.d/default.conf
+    echo '{"msg": "inotify: change detected", "level": "INFO", "file": "'$0'"}'
+
+    nginx -t -q
+    if [ $? -eq 0 ]
+    then
+      # config is valid, reload nginx config
+      set +e # don't exit on error (e.g. nginx not yet started)
+      echo '{"msg": "valid config, reloading", "level": "INFO", "file": "'$0'"}'
+      nginx -q -s reload
+      set -e
+    else
+      # config is invalid, log the error and exit
+      echo '{"msg": "invalid config", "level": "FATAL", "file": "'$0'"}'
+      nginx -t
+      exit 1
+    fi
+  entrypoint.sh: |
+    #!/bin/sh
+    set -eu -o pipefail
+
+    # Generate self-signed SSL certs (not great!)
+    apk add openssl inotify-tools && openssl req -x509 -nodes -days 3650 -subj "/C=NA/ST=NA/O=NA/CN=NA" -newkey rsa:2048 -keyout /etc/nginx/ssl.key -out /etc/nginx/ssl.crt
+
+    /reloader.sh # initial config
+
+    # Watch for changes to the bound service account token or configmap and reload nginx config
+    inotifyd reloader.sh /var/run/secrets/kubernetes.io/serviceaccount/token:n &
+    inotifyd reloader.sh /multiplexer-nginx.conf:n &
 
     # Finally, start up nginx
     nginx -g 'daemon off;'
 
   multiplexer-nginx.conf: |
+    log_format logger-json escape=json '{"source": "nginx", "time": $msec, "resp_body_size": $body_bytes_sent, "host": "$http_host", "address": "$remote_addr", "request_length": $request_length, "method": "$request_method", "uri": "$request_uri", "status": $status,  "user_agent": "$http_user_agent", "resp_time": $request_time, "proxy_host": "$proxy_host", "upstream_addr": "$upstream_addr"}';
+
     server {
-     listen 443 ssl;
-     ssl_certificate      /etc/nginx/ssl.crt;
-     ssl_certificate_key  /etc/nginx/ssl.key;
 
-     resolver kube-dns.kube-system.svc.cluster.local valid=5s;
+      {{ if eq $.Values.logging.access.level "errors"}}
+      map $status $loggable {
+        ~^[23]  0;
+        default 1;
+      }
+      access_log /dev/stdout logger-json if=$loggable;
+      {{ else if eq $.Values.logging.access.level "all"}}
+      access_log /dev/stdout logger-json;
+      {{- end }}
 
-     # Ensure correct rewrites
-     rewrite_log on;
-     error_log   /dev/stdout notice;
+      listen 8443 ssl;
+      ssl_certificate      /etc/nginx/ssl.crt;
+      ssl_certificate_key  /etc/nginx/ssl.key;
 
-     # Healthcheck
-     location = /health {
-       return 200 'ok';
-     }
+      resolver kube-dns.kube-system.svc.cluster.local valid=5s;
 
-     # Authorization: use the ServiceAccount Token
-     # (Replaced with actual value in entrypoint.sh)
-     set $authz "Bearer KUBERNETESAUTHTOKEN";
+      # Ensure correct rewrites
+      rewrite_log on;
+      error_log   /dev/stdout {{  $.Values.logging.error.level }};
 
-     {{ range $.Values.metricsProviders }}
-     # {{ .name }}
-     set ${{ .name }} {{ .service }};
-     location ~* /apis/external.metrics.k8s.io/v1beta1/namespaces/.*/{{ .prefix }} {
-       {{ if .strip_prefix }}
-       rewrite ^(/apis/external.metrics.k8s.io/v1beta1/namespaces/.*)/{{ .prefix }}(.*)$ $1/$2 break;
-       {{ end }}
-       proxy_set_header Authorization $authz;
-       proxy_pass https://${{ .name }}$uri$is_args$args;
-     }
-     {{ end }}
+      # Authorization: use the ServiceAccount Token
+      # (Replaced with actual value by reloader.sh)
+      set $authz "Bearer KUBERNETESAUTHTOKEN";
+      proxy_set_header Authorization $authz;
 
-     # Catch-all: API base
-     set $defaultupstream {{ $.Values.defaultProviderUrl }};
-     location ~* /apis/external.metrics.k8s.io/v1beta1/ {
-       proxy_set_header Authorization $authz;
-       proxy_pass https://$defaultupstream;
-     }
-     location / {
-       proxy_set_header Authorization $authz;
-       proxy_pass https://$defaultupstream;
-     }
+      # Healthcheck
+      location = /health {
+        return 200 'ok';
+      }
+
+      {{ range $.Values.metricsProviders }}
+      # {{ .name }}
+      set ${{ .name }} {{ .service }};
+      location ~* /apis/external.metrics.k8s.io/v1beta1/namespaces/.*/{{ .prefix }} {
+        {{ if .strip_prefix }}
+        rewrite ^(/apis/external.metrics.k8s.io/v1beta1/namespaces/.*)/{{ .prefix }}(.*)$ $1/$2 break;
+        {{- end }}
+        proxy_pass https://${{ .name }}$uri$is_args$args;
+      }
+      {{ end }}
+
+      # Catch-all: API base
+      set $defaultupstream {{ $.Values.defaultProviderUrl }};
+      location ~* /apis/external.metrics.k8s.io/v1beta1/ {
+        proxy_pass https://$defaultupstream;
+      }
+      location / {
+        proxy_pass https://$defaultupstream;
+      }
     }

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: metricsmultiplexer
 spec:
-  replicas: 1
+  replicas: {{ $.Values.replicas }}
   selector:
     matchLabels:
       app: metricsmultiplexer
@@ -22,10 +22,14 @@ spec:
         {{ if $.Values.resources }}
         resources:
 {{ toYaml $.Values.resources | indent 10 }}
-        {{ end }}
+        {{- end }}
         command:
         - "sh"
         - "/multiplexer-entrypoint.sh"
+        ports:
+        - name: https
+          containerPort: 8443
+          protocol: TCP
         volumeMounts:
         - name: config
           mountPath: /multiplexer-entrypoint.sh
@@ -33,7 +37,11 @@ spec:
         - name: config
           mountPath: /multiplexer-nginx.conf
           subPath: multiplexer-nginx.conf
+        - name: config
+          mountPath: /reloader.sh
+          subPath: reloader.sh
       volumes:
       - name: config
         configMap:
           name: metricsmultiplexer
+          defaultMode: 0544

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -12,4 +12,4 @@ spec:
   - name: https
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,16 @@ resources:
 # Set to false if you'd like to create it manually
 createApiService: true
 
+logging:
+  access:
+    # Access logging (json format)
+    # "all", "off", or "errors"
+    level: "off"
+  error:
+    # Error logging (text format)
+    # "debug", "info", "notice", "warn", "error", "crit", "alert", or "emerg"
+    level: notice
+
 # URL of the default metrics provider which provides the base path, for example:
 #
 # defaultProviderUrl: prometheus-adapter.prometheus.svc.cluster.local


### PR DESCRIPTION
- Reload on service account token change (required for K8s > 1.22) using inotify
- Add configurable logging for nginx access and error logs
- Use json format logs
- Switch to port 8443 to one day allow non-root (maybe)
- Use the named port `https` in the service
- Move all `proxy_set_headers` to the `server` block, since they are identical this is acceptable
- Fix replica templating (was hardcoded to 2)
- Tidy some easily-fixed linebreaks in the config template
- `set -eu -o pipefail` in the entrypoint (pipefail supported by busybox ash and now in in POSIX)